### PR TITLE
add memoization support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,4 +35,5 @@ declare module 'quarx' {
   }
 
   export function computed<T>(computation: () => T, options?: ObservableOptions<T>): Observable<T>;
+  export function memoizeOne<T>(computation: () => T): Observable<T>;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export { Quarx, createAtom, autorun, batch, untracked } from './src/core';
 export { computed } from './src/computed';
+export { memoizeOne } from './src/memoize';
 import { box } from './src/box'
 export const observable = { box };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "build": "esbuild index.js --bundle --platform=node --outfile=dist/index.js",
+    "build": "esbuild index.js --sourcemap --bundle --platform=node --outfile=dist/index.js",
     "test": "ava -v",
     "perf": "ava -v --config test.perf.config.js --node-arguments='--expose-gc'"
   },

--- a/src/box.js
+++ b/src/box.js
@@ -9,6 +9,7 @@ export function box(value, options = {}) {
   const atom = createAtom(null, { name });
 
   return {
+    equals(other) { return equals(value, other) },
     set(newValue) {
       if (!equals(newValue, value)) {
         value = newValue;
@@ -16,7 +17,7 @@ export function box(value, options = {}) {
       }
     },
     get() {
-      atom.reportObserved();
+      atom.reportObserved(this, value);
       return value;
     }
   };

--- a/src/core.js
+++ b/src/core.js
@@ -10,6 +10,7 @@ if (Quarx) {
 }
 else Quarx = GLOBAL[TAG] = {
   stack: [],
+  observedMapStack: [],
   invalidated: new Set(),
   pendingDispose: new Set(),
   sequenceNumber: 0,
@@ -35,9 +36,10 @@ export function createAtom(onBecomeObserved, options = {}) {
   let dispose, actualize;
 
   return {
-    reportObserved() {
+    reportObserved(observable, val) {
       // console.debug(`[Quarx]: ${name} observed`);
       const { invalidate, link } = Quarx.stack[Quarx.stack.length - 1] || {};
+      if (observable) Quarx.observedMapStack.forEach(frame => frame.set(observable, val))
       if (!invalidate) return false;
 
       if (!observers.size) {

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,0 +1,35 @@
+import { Quarx } from './core';
+
+export function memoizeOne(fn) {
+  let previousInputs = new Map();
+  let previousResult = undefined;
+  return {
+    get: function () {
+      let cacheHit = previousInputs.size > 0;
+      // console.debug(`[Quarx.memoize]: Start: Checking cache. ${previousInputs.size} boxed values`);
+      for (const [box, value] of previousInputs.entries()) {
+        if (!box.equals(value)) {
+          cacheHit = false;
+          break;
+        }
+      }
+
+      if (cacheHit) {
+        // console.debug(`[Quarx.memoize]: End: Cache hit. Returning `, previousResult);
+        for (const [box, value] of previousInputs.entries()) {
+          Quarx.observedMapStack.forEach(frame => frame.set(box, value));
+        }
+        return previousResult;
+      }
+
+      // console.debug(`[Quarx.memoize]: Cache miss. Executing...`);
+      previousInputs = new Map();
+      Quarx.observedMapStack.push(previousInputs);
+      previousResult = fn();
+      Quarx.observedMapStack.pop();
+
+      // console.debug(`[Quarx.memoize]: End: Returning`, previousResult);
+      return previousResult;
+    }
+  }
+}

--- a/tests/memoize.spec.js
+++ b/tests/memoize.spec.js
@@ -1,0 +1,93 @@
+const test = require('ava');
+const { autorun, observable, memoizeOne, batch } = require('../dist/index');
+
+let a, b, c, d
+let sumABdidRecompute, sumCDdidRecompute, sumAllDidRecompute
+let sumAB, sumCD, sumAll
+
+function clearRecomputeFlags() {
+  sumABdidRecompute = false
+  sumCDdidRecompute = false
+  sumAllDidRecompute = false
+}
+
+test.beforeEach(() => {
+  a = observable.box(1, {name: 'a'});
+  b = observable.box(2, {name: 'b'});
+  c = observable.box(3, {name: 'c'});
+  d = observable.box(4, {name: 'd'});
+
+  clearRecomputeFlags()
+
+  sumAB = memoizeOne(() => (sumABdidRecompute = true) && a.get() + b.get())
+  sumCD = memoizeOne(() => (sumCDdidRecompute = true) && c.get() + d.get())
+  sumAll = memoizeOne(() => (sumAllDidRecompute = true) && sumAB.get() + sumCD.get())
+})
+
+test('has a cache hit on second invocation', t => {
+  const a = observable.box(3);
+  let didRecompute = false
+  const square = memoizeOne(() => (didRecompute = true) && a.get() * a.get())
+
+  t.is(square.get(), 9)
+  t.true(didRecompute)
+  didRecompute = false
+  t.is(square.get(), 9)
+  t.false(didRecompute)
+})
+
+test('has a cache hit with nested memoized functions', t => {
+    t.is(sumAll.get(), 10)
+    t.true(sumABdidRecompute)
+    t.true(sumCDdidRecompute)
+    t.true(sumAllDidRecompute)
+
+    // second invocation results in cache hit and does not compute sumAB and sumCD
+    clearRecomputeFlags()
+    t.is(sumAll.get(), 10)
+    t.false(sumABdidRecompute)
+    t.false(sumCDdidRecompute)
+    t.false(sumAllDidRecompute)
+  })
+
+  test('invalidates parent memoize when nested box changes', t => {
+    t.is(sumAll.get(), 10)
+
+    a.set(5)
+
+    clearRecomputeFlags()
+    t.is(sumAll.get(), 14)
+
+    t.true(sumABdidRecompute)
+    t.false(sumCDdidRecompute)
+    t.true(sumAllDidRecompute)
+  })
+
+  test.serial('autorun and batch still work', t => {
+    let recomputeStats = []
+    let actualSum = null
+    autorun(() => {
+      clearRecomputeFlags()
+      actualSum = sumAll.get()
+      recomputeStats.push([sumABdidRecompute, sumCDdidRecompute, sumAllDidRecompute])
+    })
+
+    t.is(actualSum, 10)
+    t.is(recomputeStats.length, 1)
+    t.deepEqual(recomputeStats.pop(), [true, true, true])
+
+    a.set(5)
+    t.is(actualSum, 14)
+    t.is(recomputeStats.length, 1)
+    t.deepEqual(recomputeStats.pop(), [true, false, true])
+
+    batch(() => {
+      a.set(-1)
+      b.set(-2)
+      c.set(-3)
+      d.set(-4)
+    })
+    t.is(actualSum, -10)
+    t.is(recomputeStats.length, 1)
+    t.deepEqual(recomputeStats.pop(), [true, true, true])
+  })


### PR DESCRIPTION
Thanks for the great library!

It may be nice to use the dependency graph to invalidate memoized computation.

To memoize an expensive computation users can just replace `computed(...)` with `memoizeOne(...)`.

Other solutions like [memoize-one](https://github.com/alexreardon/memoize-one) require passing in all the inputs as arguments to the function that is memoized.